### PR TITLE
Centrilized OpenTelemetry configurations

### DIFF
--- a/BankApi.Core/Defaults/Builder.Logging.cs
+++ b/BankApi.Core/Defaults/Builder.Logging.cs
@@ -6,13 +6,12 @@ public static partial class ApiBuilder
 {
     public static IHostApplicationBuilder AddLoggingServices(this IHostApplicationBuilder builder)
     {
-        builder.Logging.AddOpenTelemetry(logging =>
-        {
-            logging.IncludeFormattedMessage = true;
-            logging.IncludeScopes = true;
-        });
-
         var otel = builder.Services.AddOpenTelemetry();
+        otel.WithLogging(logging => { }, options =>
+        {
+            options.IncludeFormattedMessage = true;
+            options.IncludeScopes = true;
+        });
         otel.WithMetrics(metrics =>
         {
             metrics.AddAspNetCoreInstrumentation();


### PR DESCRIPTION
I think it is confusing to register OpenTelemetry twice, once for `ILoggingBuilder` and once for `IServiceCollection`.

With this PR we are centralizing all the OpenTelemetry configurations in the `OpenTelemetryBuilder`